### PR TITLE
Lock conan version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Install conan, meson, ninja and gcovr
-      run: pip install conan meson ninja gcovr
+      run: pip install conan==1.59.0 meson ninja gcovr
       shell: bash
 
     - name: Create default profile


### PR DESCRIPTION
Locks the conan version used in CI to 1.59.0, so that there are no issues during migration to conan v2.